### PR TITLE
import 3 additional modules which are used within draw_scene.py

### DIFF
--- a/utils/draw_scene.py
+++ b/utils/draw_scene.py
@@ -1,5 +1,7 @@
 import random
 import warnings
+import sys
+import io
 
 import matplotlib.cm
 import matplotlib.colors as mplcolors
@@ -12,6 +14,7 @@ import fresnel
 import freud
 import mbuild as mb
 import PIL
+import IPython
 
 device = fresnel.Device(mode='cpu');
 preview_tracer = fresnel.tracer.Preview(device, 300, 300)


### PR DESCRIPTION
This fixes the import errors discussed in issue #4 

Since these packages are used within `draw_scene.py` they should probably be explicitly imported within the same file. 

@jennyfothergill maybe you know something I don't, but how were you able to get `display_movie` to work without these packages being imported in `draw_scene.py`?