### PR TITLE
Install gaff in editable mode for setuptools

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,4 +20,4 @@ dependencies:
   - nodejs>=10
   - jupyterlab
   - pip:
-    - git+https://github.com/rsdefever/GAFF-foyer
+    - "--editable=git+https://github.com/rsdefever/GAFF-foyer.git#egg=gaff_foyer-master"


### PR DESCRIPTION
The installation of gaff_foyer with pip was missing the editable flag to
generate an egg file to allow foyer to detect it as a forcefield plugin.

This modifies the environment.yml file to support this install method,
to allow for setuptools to properly discover the gaff plugin.

I think this is due to the standard pip install being located in some temporary location, and then setuptools can never traverse where it was downloaded and installed. 

I just tested this and it seems to work.