### PR TITLE
cleanup CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,8 @@
 name: Test PR and Image
-on: pull_request_target
-  pull_request:
-    branches: [ master ]
 
+on:
+  pull_request_target:
+    branches: [ master ]
 jobs:
   build-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,38 +1,28 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
-on:
-  push:
-    branches: [ master ]
+name: Test PR and Image
+on: pull_request_target
   pull_request:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  cache-mybinder:
+  build-image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: update jupyter dependencies with repo2docker
+      - name: Build Image
         uses: jupyterhub/repo2docker-action@master
         with:
-          NO_PUSH: 'true'
-          MYBINDERORG_TAG: ${{ github.event.ref }}
-          #DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          #DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          #IMAGE_NAME: "cmelab/notebook-tutorials"
+          LATEST_TAG_OFF: 'true'
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          IMAGE_NAME: "cmelab/notebook-tutorials"
   
   test:
-    #needs: [construct-container]
     runs-on: ubuntu-latest
     container: 
-      image: cmelab/notebook-tutorials    
+      image: cmelab/notebook-tutorials:${{ github.event.pull_request.head.sha }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,6 @@
 name: Test PR and Image
 
-on:
-  push:
-    branches: [ master ]
-  pull_request_target:
-    branches: [ master ]
-
+on: [pull_request_target]
 
 jobs:
   build-image:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,9 @@ name: Test PR and Image
 on:
   pull_request_target:
     branches: [ master ]
+  push:
+    branches: [ master ]
+
 jobs:
   build-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,11 @@
 name: Test PR and Image
 
 on:
-  pull_request:
-    branches: [ master ]
   push:
     branches: [ master ]
+  pull_request_target:
+    branches: [ master ]
+
 
 jobs:
   build-image:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: Test PR and Image
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ master ]
   push:
     branches: [ master ]


### PR DESCRIPTION
Okay so now we only push the image/cache the mybinder image when we merge to master, and now PRs build an image, then we pull the image. Depending on how things are setup on github's side, this will either be fast or slow...